### PR TITLE
Terminate a buffer chunk by "," instead of "\n"

### DIFF
--- a/lib/fluent/plugin/out_cloudsearch.rb
+++ b/lib/fluent/plugin/out_cloudsearch.rb
@@ -64,12 +64,12 @@ module Fluent
         return ''
       end
 
-      "#{record.to_json}\n"
+      "#{record.to_json},"
     end
 
     def write(chunk)
       documents = '['
-      documents << chunk.read.split("\n").join(",")
+      documents << chunk.read.chop  # chop last ','
       documents << ']'
       resp = @client.upload_documents(
         :documents => documents,

--- a/test/plugin/test_out_cloudsearch.rb
+++ b/test/plugin/test_out_cloudsearch.rb
@@ -110,9 +110,9 @@ class CloudSearchOutputTest < Test::Unit::TestCase
     d.emit({'id' => 'x5234', 'type' => 'add', 'fields' => {'foo' => 3, 'bar' => 'b'}})
     d.emit({'id' => 'x3234'}) # ignore because type is not exists
 
-    d.expect_format %[{"id":"x1234","type":"add","fields":{"foo":1,"bar":"a"}}\n]
-    d.expect_format %[{"id":"y2234","type":"delete"}\n]
-    d.expect_format %[{"id":"x5234","type":"add","fields":{"foo":3,"bar":"b"}}\n]
+    d.expect_format %[{"id":"x1234","type":"add","fields":{"foo":1,"bar":"a"}},]
+    d.expect_format %[{"id":"y2234","type":"delete"},]
+    d.expect_format %[{"id":"x5234","type":"add","fields":{"foo":3,"bar":"b"}},]
 
     d.run
 


### PR DESCRIPTION
For more performance. split and join requires more CPU cost than simply chop.

```
$ ruby bench.rb 10000
                 user     system      total        real
split-join   3.960000   0.050000   4.010000 (  4.033248)
chop         0.240000   0.280000   0.520000 (  0.559678)
$ ruby -v
ruby 2.1.6p336 (2015-04-13 revision 50298) [x86_64-darwin14.0]
```

``` ruby
require "benchmark"
require "json"

d = {'id' => 'x5234', 'type' => 'add', 'fields' => {'foo' => 3, 'bar' => 'b'}}.to_json
d_lf = ""
d_comma = ""
1.upto 1000 do
  d_lf << "#{d}\n"
  d_comma << "#{d},"
end
n = ARGV[0].to_i

Benchmark.bm 10 do |r|
  r.report "split-join" do
    n.times do
      documents = "["
      documents << d_lf.split("\n").join(",")
      documents << "]"
    end
  end

  r.report "chop" do
    n.times do
      documents = "["
      documents << d_comma.chop
      documents << "]"
    end
  end
end
```
