### PR TITLE
endpoint param is required

### DIFF
--- a/lib/fluent/plugin/out_cloudsearch.rb
+++ b/lib/fluent/plugin/out_cloudsearch.rb
@@ -29,6 +29,9 @@ module Fluent
 
       super
 
+      unless @endpoint
+        raise ConfigError, "'endpoint' parameter is required"
+      end
       if @buffer.buffer_chunk_limit > MAX_SIZE_LIMIT
         raise ConfigError, "buffer_chunk_limit must be less than #{MAX_SIZE_LIMIT}"
       end
@@ -37,7 +40,7 @@ module Fluent
     def start
       super
       options = setup_credentials
-      options[:endpoint] = @endpoint if @endpoint
+      options[:endpoint] = @endpoint
       options[:region] = @region if @region
       @client = Aws::CloudSearchDomain::Client.new(options)
     end

--- a/test/plugin/test_out_cloudsearch.rb
+++ b/test/plugin/test_out_cloudsearch.rb
@@ -38,6 +38,12 @@ class CloudSearchOutputTest < Test::Unit::TestCase
       ]
     }
 
+    assert_raise(Fluent::ConfigError) {
+      d = create_driver %[
+        buffer_chunk_limit 1M
+      ]
+    }
+
     d = create_driver %[
       endpoint http://example.com
       profile_name foo-doc


### PR DESCRIPTION
`endpoint` parameter is required to consuruct Aws::CloudSearchDomain::Client.

http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudSearchDomain/Client.html

> To construct a client, you must configure the :endpoint option:
