### PR TITLE
replace invalid characters to white space in fields.

### DIFF
--- a/test/plugin/test_out_cloudsearch.rb
+++ b/test/plugin/test_out_cloudsearch.rb
@@ -115,10 +115,12 @@ class CloudSearchOutputTest < Test::Unit::TestCase
     d.emit({'id' => 'x4234', 'type' => 'add'}) # ignore because fields is not exits
     d.emit({'id' => 'x5234', 'type' => 'add', 'fields' => {'foo' => 3, 'bar' => 'b'}})
     d.emit({'id' => 'x3234'}) # ignore because type is not exists
+    d.emit({'id' => 'x6789', 'type' => 'add', 'fields' => {'foo' => 1, 'bar' => "foo\u0014bar"}})
 
     d.expect_format %[{"id":"x1234","type":"add","fields":{"foo":1,"bar":"a"}},]
     d.expect_format %[{"id":"y2234","type":"delete"},]
     d.expect_format %[{"id":"x5234","type":"add","fields":{"foo":3,"bar":"b"}},]
+    d.expect_format %[{"id":"x6789","type":"add","fields":{"foo":1,"bar":"foo bar"}},]
 
     d.run
 

--- a/test/plugin/test_out_cloudsearch.rb
+++ b/test/plugin/test_out_cloudsearch.rb
@@ -116,11 +116,13 @@ class CloudSearchOutputTest < Test::Unit::TestCase
     d.emit({'id' => 'x5234', 'type' => 'add', 'fields' => {'foo' => 3, 'bar' => 'b'}})
     d.emit({'id' => 'x3234'}) # ignore because type is not exists
     d.emit({'id' => 'x6789', 'type' => 'add', 'fields' => {'foo' => 1, 'bar' => "foo\u0014bar"}})
+    d.emit({'id' => 'x7890', 'type' => 'add', 'fields' => {'foo' => 1, 'bar' => "あいうえお\u0020\u0008かきくけこ\u0007さしすせそ\nたちつてと"}})
 
     d.expect_format %[{"id":"x1234","type":"add","fields":{"foo":1,"bar":"a"}},]
     d.expect_format %[{"id":"y2234","type":"delete"},]
     d.expect_format %[{"id":"x5234","type":"add","fields":{"foo":3,"bar":"b"}},]
     d.expect_format %[{"id":"x6789","type":"add","fields":{"foo":1,"bar":"foo bar"}},]
+    d.expect_format %[{"id":"x7890","type":"add","fields":{"foo":1,"bar":"あいうえお  かきくけこ さしすせそ\\nたちつてと"}},]
 
     d.run
 


### PR DESCRIPTION
We encountered CloudSearch error responses below.

```
2016-03-25 22:01:55 +0900 [warn]: temporarily failed to flush the buffer. 
next_retry=2016-03-25 22:01:54 +0900 error_class="Aws::CloudSearchDomain::Errors::DocumentServiceException" 
error="{ [\"Validation error for field 'message': Invalid codepoint 14\"] }" 
plugin_id="object:3fa31d270e98"
```

AWS Document https://docs.aws.amazon.com/ja_jp/cloudsearch/latest/developerguide/preparing-data.html suggests to remove invalid characters by regexp `/[^\u0009\u000a\u000d\u0020-\uD7FF\uE000-\uFFFD]/`.
